### PR TITLE
Adding 2Checkout payment method

### DIFF
--- a/core/gateways/class_wpi_twocheckout.php
+++ b/core/gateways/class_wpi_twocheckout.php
@@ -1,0 +1,418 @@
+<?php
+/**
+Name: 2Checkout
+Class: wpi_twocheckout
+Internal Slug: wpi_twocheckout
+JS Slug: wpi_twocheckout
+Version: 1.0
+Description: Provides the 2Checkout for payment options
+*/
+
+class wpi_twocheckout extends wpi_gateway_base {
+
+	/**
+   * Input types
+   */
+  const TEXT_INPUT_TYPE   = 'text';
+  const SELECT_INPUT_TYPE = 'select';
+
+	/**
+	 * Payment settings
+	 *
+	 * @var array
+	 */
+  var $options = array(
+    'name' => '2Checkout',
+    'allow' => '',
+    'default_option' => '',
+    'settings' => array(
+      'twocheckout_sid' => array(
+        'label' => "2Checkout Seller ID",
+        'value' => ''
+      ),
+      'twocheckout_secret' => array(
+        'label' => "2Checkout Secret Word",
+        'value' => ''
+      ),
+      'test_mode' => array(
+        'label' => "Demo Mode",
+        'description' => "Use 2Checkout Demo Mode",
+        'type' => 'select',
+        'value' => 'N',
+        'data' => array(
+          'N' => "No",
+          'Y' => "Yes"
+        )
+      ),
+      'direct_checkout' => array(
+          'label' => "Direct Checkout",
+          'description' => "Use Direct Checkout",
+          'type' => 'select',
+          'value' => 'Y',
+          'data' => array(
+              'N' => "No",
+              'Y' => "Yes"
+          )
+      ),
+      'button_url' => array(
+        'label' => "2Checkout Button URL",
+        'value' => "https://www.2checkout.com/images/paymentlogoshorizontal.png"
+      ),
+      'ipn' => array(
+        'label' => "2Checkout Approved URL/INS URL",
+        'type' => "readonly",
+        'description' => "Set this URL as your Approved URL in your 2Checkout Site Management page and Notification URL under your 2Checkout Notification page."
+      )
+    )
+  );
+
+	/**
+   * Fields list for frontend
+   */
+  var $front_end_fields = array(
+
+    'customer_information' => array(
+
+      'first_name'  => array(
+        'type'  => 'text',
+        'class' => 'text-input',
+        'name'  => 'first_name',
+        'label' => 'First Name'
+      ),
+
+      'last_name'   => array(
+        'type'  => 'text',
+        'class' => 'text-input',
+        'name'  => 'last_name',
+        'label' => 'Last Name'
+      ),
+
+      'user_email'  => array(
+        'type'  => 'text',
+        'class' => 'text-input',
+        'name'  => 'email_address',
+        'label' => 'Email Address'
+      ),
+
+			'phonenumber' => array(
+				array(
+					'type'  => 'text',
+					'class' => 'text-input small',
+					'name'  => 'night_phone_a'
+				),
+				array(
+					'type'  => 'text',
+					'class' => 'text-input small',
+					'name'  => 'night_phone_b'
+				),
+				array(
+					'type'  => 'text',
+					'class' => 'text-input small',
+					'name'  => 'night_phone_c'
+				)
+			),
+
+      'streetaddress'     => array(
+        'type'  => 'text',
+        'class' => 'text-input',
+        'name'  => 'address1',
+        'label' => 'Address'
+      ),
+
+      'city'        => array(
+        'type'  => 'text',
+        'class' => 'text-input',
+        'name'  => 'city',
+        'label' => 'City'
+      ),
+
+      'state'       => array(
+        'type'   => 'text',
+        'class'  => 'text-input',
+        'name'   => 'state',
+        'label'  => 'State/Province'
+      ),
+
+      'zip'         => array(
+        'type'  => 'text',
+        'class' => 'text-input',
+        'name'  => 'zip',
+        'label' => 'Zip/Postal Code'
+      ),
+
+      'country'     => array(
+        'type'   => 'text',
+        'class'  => 'text-input',
+        'name'   => 'country',
+        'label'  => 'Country'
+      )
+
+    )
+
+  );
+
+	/**
+	 * Constructor
+	 */
+  function __construct() {
+    parent::__construct();
+    $this->options['settings']['ipn']['value'] = admin_url('admin-ajax.php?action=wpi_gateway_server_callback&type=wpi_twocheckout');
+
+		add_action( 'wpi_payment_fields_twocheckout', array( $this, 'wpi_payment_fields' ) );
+	}
+
+	/**
+	 * Overrided payment process for 2Checkout
+	 *
+	 * @global type $invoice
+	 * @global type $wpi_settings
+	 */
+	function process_payment() {
+		global $invoice, $wpi_settings;
+
+		$crm_data    = $_REQUEST['crm_data'];
+    $invoice_id  = $invoice['invoice_id'];
+    $wp_users_id = $invoice['user_data']['ID'];
+    $post_id     = wpi_invoice_id_to_post_id($invoice_id);
+
+		// update user data
+		update_user_meta($wp_users_id, 'last_name', $_REQUEST['last_name']);
+		update_user_meta($wp_users_id, 'first_name', $_REQUEST['first_name']);
+		update_user_meta($wp_users_id, 'city', $_REQUEST['city']);
+		update_user_meta($wp_users_id, 'state', $_REQUEST['state']);
+		update_user_meta($wp_users_id, 'zip', $_REQUEST['zip']);
+		update_user_meta($wp_users_id, 'streetaddress', $_REQUEST['address1']);
+		update_user_meta($wp_users_id, 'phonenumber', $_REQUEST['night_phone_a'].'-'.$_REQUEST['night_phone_b'].'-'.$_REQUEST['night_phone_c']);
+		update_user_meta($wp_users_id, 'country', $_REQUEST['country']);
+
+		if ( !empty( $crm_data ) ) $this->user_meta_updated( $crm_data );
+
+		echo json_encode(
+		  array( 'success' => 1 )
+		);
+
+	}
+
+	/**
+   * Render fields
+   *
+   * @param array $invoice
+   */
+  function wpi_payment_fields( $invoice ) {
+
+    $this->front_end_fields = apply_filters( 'wpi_crm_custom_fields', $this->front_end_fields, 'crm_data' );
+
+    if ( !empty( $this->front_end_fields ) ) {
+      // For each section
+      foreach( $this->front_end_fields as $key => $value ) {
+        // If section is not empty
+        if ( !empty( $this->front_end_fields[ $key ] ) ) {
+					$html = '';
+					ob_start();
+
+					?>
+					<ul class="wpi_checkout_block">
+						<li class="section_title"><?php _e( ucwords( str_replace('_', ' ', $key) ), WPI); ?></li>
+					<?php
+					$html = ob_get_contents();
+					ob_end_clean();
+					echo $html;
+          // For each field
+          foreach( $value as $field_slug => $field_data ) {
+
+						// If field is set of 3 fields for 2Checkout phone number
+						if ( $field_slug == 'phonenumber' ) {
+
+							echo '<li class="wpi_checkout_row"><div class="control-group"><label class="control-label">'.__('Phone Number', WPI).'</label><div class="controls">';
+
+							$phonenumber = !empty($invoice['user_data']['phonenumber']) ? $invoice['user_data']['phonenumber'] : "---";
+							$phone_array = split('[/.-]', $phonenumber);
+
+							foreach( $field_data as $field ) {
+                //** Change field properties if we need */
+                $field = apply_filters('wpi_payment_form_styles', $field, $field_slug, 'wpi_twocheckout');
+								ob_start();
+                ?>
+                  <input type="<?php echo esc_attr( $field['type'] ); ?>" class="<?php echo esc_attr( $field['class'] ); ?>"  name="<?php echo esc_attr( $field['name'] ); ?>" value="<?php echo esc_attr( $phone_array[key($phone_array)] ); next($phone_array); ?>" />
+                <?php
+                $html = ob_get_contents();
+                ob_end_clean();
+								echo $html;
+							}
+
+							echo '</div></div></li>';
+
+						}
+            //** Change field properties if we need */
+            $field_data = apply_filters('wpi_payment_form_styles', $field_data, $field_slug, 'wpi_twocheckout');
+
+            $html = '';
+            switch ( $field_data['type'] ) {
+              case self::TEXT_INPUT_TYPE:
+
+                ob_start();
+
+                ?>
+
+                <li class="wpi_checkout_row">
+                  <div class="control-group">
+                    <label class="control-label" for="<?php echo esc_attr( $field_slug ); ?>"><?php _e($field_data['label'], WPI); ?></label>
+                    <div class="controls">
+                      <input type="<?php echo esc_attr( $field_data['type'] ); ?>" class="<?php echo esc_attr( $field_data['class'] ); ?>"  name="<?php echo esc_attr( $field_data['name'] ); ?>" value="<?php echo !empty($invoice['user_data'][$field_slug])?$invoice['user_data'][$field_slug]:'';?>" />
+                    </div>
+                  </div>
+                </li>
+
+                <?php
+
+                $html = ob_get_contents();
+                ob_end_clean();
+
+                break;
+
+              case self::SELECT_INPUT_TYPE:
+
+                ob_start();
+
+                ?>
+
+                <li class="wpi_checkout_row">
+                  <label for="<?php echo esc_attr( $field_slug ); ?>"><?php _e($field_data['label'], WPI); ?></label>
+                  <?php echo WPI_UI::select("name={$field_data['name']}&values={$field_data['values']}&id={$field_slug}&class={$field_data['class']}"); ?>
+                </li>
+
+                <?php
+
+                $html = ob_get_contents();
+                ob_clean();
+
+                break;
+
+              default:
+                break;
+            }
+
+            echo $html;
+
+          }
+					echo '</ul>';
+        }
+      }
+
+    }
+
+  }
+
+  /**
+   * Handler for 2Checkout Callback
+   * @author Craig Christenson
+   * Full callback URL: http://domain/wp-admin/admin-ajax.php?action=wpi_gateway_server_callback&type=wpi_twocheckout
+   */
+  function server_callback(){
+
+    if ( empty( $_REQUEST ) ) die(__('Direct access not allowed', WPI));
+
+    $invoice = new WPI_Invoice();
+    $invoice->load_invoice("id={$_REQUEST['merchant_order_id']}");
+
+    /** Verify callback request */
+    if ( $this->_ipn_verified( $invoice ) ) {
+      if ($_REQUEST['key']) {
+        $event_note = sprintf(__('%s paid via 2Checkout', WPI), WPI_Functions::currency_format(abs($_REQUEST['total']), $_REQUEST['merchant_order_id']));
+        $event_amount = (float)$_REQUEST['total'];
+        $event_type   = 'add_payment';
+        /** Log balance changes */
+        $invoice->add_entry("attribute=balance&note=$event_note&amount=$event_amount&type=$event_type");
+        /** Log payer email */
+        $payer_email = sprintf(__("2Checkout buyer email: %s", WPI), $_REQUEST['email']);
+        $invoice->add_entry("attribute=invoice&note=$payer_email&type=update");
+        $invoice->save_invoice();
+        /** ... and mark invoice as paid */
+        wp_invoice_mark_as_paid( $_REQUEST['invoice'], $check = true );
+        send_notification( $invoice->data );
+        echo '<script type="text/javascript">window.location="'.$_REQUEST['x_receipt_link_url'].'";</script>';
+
+      /** Handle INS messages */
+      } elseif ($_POST['md5_hash']) {
+
+        switch ( $_POST['message_type'] ) {
+
+          case 'FRAUD_STATUS_CHANGED':
+            if ($_POST['fraud_status'] == 'pass') {
+              WPI_Functions::log_event(wpi_invoice_id_to_post_id($_POST['vendor_order_id']), 'invoice', 'update', '', __('Passed 2Checkout fraud review.', WPI));
+            } elseif (condition) {
+              WPI_Functions::log_event(wpi_invoice_id_to_post_id($_POST['vendor_order_id']), 'invoice', 'update', '', __('Failed 2Checkout fraud review.', WPI));
+              wp_invoice_mark_as_pending( $_POST['vendor_order_id'] );
+            }
+            break;
+
+          case 'RECURRING_STOPPED':
+            WPI_Functions::log_event(wpi_invoice_id_to_post_id($_POST['vendor_order_id']), 'invoice', 'update', '', __('Recurring billing stopped.', WPI));
+            break;
+
+          case 'RECURRING_INSTALLMENT_FAILED':
+            WPI_Functions::log_event(wpi_invoice_id_to_post_id($_POST['vendor_order_id']), 'invoice', 'update', '', __('Recurring installment failed.', WPI));
+            break;
+
+          case 'RECURRING_INSTALLMENT_SUCCESS':
+            $event_note = sprintf(__('%1s paid for subscription %2s', WPI), WPI_Functions::currency_format(abs($_POST['item_rec_list_amount_1']), $_POST['vendor_order_id']), $_POST['sale_id']);
+            $event_amount = (float)$_POST['item_rec_list_amount_1'];
+            $event_type   = 'add_payment';
+            $invoice->add_entry("attribute=balance&note=$event_note&amount=$event_amount&type=$event_type");
+            $invoice->save_invoice();
+            send_notification( $invoice->data );
+            break;
+
+          case 'RECURRING_COMPLETE':
+            WPI_Functions::log_event(wpi_invoice_id_to_post_id($_POST['vendor_order_id']), 'invoice', 'update', '', __('Recurring installments completed.', WPI));
+            wp_invoice_mark_as_paid( $_POST['invoice'], $check = false );
+            break;
+
+          case 'RECURRING_RESTARTED':
+            WPI_Functions::log_event(wpi_invoice_id_to_post_id($_POST['vendor_order_id']), 'invoice', 'update', '', __('Recurring sale restarted.', WPI));
+            break;
+
+          default:
+            break;
+        }
+      }
+    }
+  }
+
+//   /**
+//    * Verify return/notification and return TRUE or FALSE
+//    * @author Craig Christenson
+//    **/
+  private function _ipn_verified( $invoice = false ) {
+
+  	if ($_REQUEST['key']) {
+      if ($this->options['settings']['test_mode']['value'] == 'Y') {
+        $transaction_id = 1;
+      } else {
+        $transaction_id = $_REQUEST['order_number'];
+      }
+      $compare_string = $this->options['settings']['twocheckout_secret']['value'] .
+      $this->options['settings']['twocheckout_sid']['value']. $transaction_id .
+      $_REQUEST['total'];
+      $compare_hash1 = strtoupper(md5($compare_string));
+      $compare_hash2 = $_REQUEST['key'];
+      if ($compare_hash1 != $compare_hash2) {
+          die("MD5 HASH Mismatch! Make sure your demo settings are correct.");
+      } else {
+          return TRUE;
+      }
+    } elseif ($_POST['md5_hash']) {
+      $compare_string = $_POST['sale_id'] . $this->options['settings']['twocheckout_sid']['value'] . 
+      $_POST['invoice_id'] . $this->options['settings']['twocheckout_secret']['value'];
+      $compare_hash1 = strtoupper(md5($compare_string));
+      $compare_hash2 = $_POST['md5_hash'];
+      if ($compare_hash1 != $compare_hash2) {
+          die("MD5 HASH Mismatch!");
+      } else {
+          return TRUE;
+      }
+    }
+  }
+
+}
+

--- a/core/gateways/templates/wpi_twocheckout-frontend.tpl.php
+++ b/core/gateways/templates/wpi_twocheckout-frontend.tpl.php
@@ -1,0 +1,69 @@
+<?php include_once WPI_Path.'/core/wpi_template_functions.php'; ?>
+<form action="https://www.2checkout.com/checkout/spurchase" method="post" name="online_payment_form" id="online_payment_form-<?php print $this->type; ?>" class="wpi_checkout online_payment_form <?php print $this->type; ?> clearfix">
+  <input type="hidden" id="wpi_action" name="wpi_action" value="wpi_gateway_process_payment" />
+  <input type="hidden" id="wpi_form_type" name="type" value="<?php print $this->type; ?>" />
+  <input type="hidden" id="wpi_form_invoice_id" name="invoice_id" value="<?php print $invoice['invoice_id']; ?>" />
+  <input type="hidden" name="wp_invoice[hash]" value="<?php echo wp_create_nonce($invoice['invoice_id'] .'hash'); ?>" />
+  <input type="hidden" name="currency_code" value="<?php echo $invoice['default_currency_code']; ?>">
+  <input type="hidden" name="mode" value="2CO">
+  <input type="hidden" name="sid" value="<?php echo $invoice['billing']['wpi_twocheckout']['settings']['twocheckout_sid']['value']; ?>">
+  <input type="hidden" name="demo" value="<?php echo $invoice['billing']['wpi_twocheckout']['settings']['test_mode']['value']; ?>">
+  <input type="hidden" name="x_receipt_link_url" value="<?php echo get_invoice_permalink($invoice['invoice_id']); ?>">
+  <input type="hidden" name="return_url" value="<?php echo get_invoice_permalink($invoice['invoice_id']); ?>">
+  <input type="hidden" name="merchant_order_id" id="invoice_id" value="<?php echo $invoice['invoice_id']; ?>">
+
+  <input type="hidden" name="li_0_name" value="<?php echo $invoice['post_title']; ?>">
+  <?php if ( is_recurring() ): ?>
+  <?php switch ( $invoice['recurring']['unit'] ) {
+          case 'months':
+            $subscription_unit = "Month";
+            break;
+          case 'weeks':
+            $subscription_unit = "Week";
+            break;
+          case 'years':
+            $subscription_unit = "Year";
+          break;
+        }
+    ?>
+    <input type="hidden" name="li_0_description" value="Invoice ID: <?php echo $invoice['invoice_id']; ?>">
+    <input type="hidden" name="li_0_duration" value="<?php echo (int)$invoice['recurring']['cycles']; ?> <?php echo $subscription_unit; ?>">
+    <input type="hidden" name="li_0_price" value="<?php echo number_format( (float)$invoice['net'], 2, '.', '' ); ?>">
+    <input type="hidden" name="li_0_recurrence" value="<?php echo (int)$invoice['recurring']['length']; ?> <?php echo $subscription_unit; ?>">
+  <?php else: ?>
+    <input type="hidden" name="li_0_description" value="Invoice ID: <?php echo $invoice['invoice_id']; ?>">
+    <input type="hidden" name="li_0_price" value="<?php echo number_format( (float)$invoice['net'], 2, '.', '' ); ?>">
+  <?php endif; ?>
+
+  <input type="hidden" name="card_holder_name" value="<?php echo $invoice['user_data']['display_name']; ?>">
+  <input type="hidden" name="street_address" value="<?php echo $invoice['user_data']['streetaddress']; ?>">
+  <input type="hidden" name="city" value="<?php echo $invoice['user_data']['city']; ?>">
+  <input type="hidden" name="state" value="<?php echo $invoice['user_data']['state']; ?>">
+  <input type="hidden" name="zip" value="<?php echo $invoice['user_data']['zip']; ?>">
+  <input type="hidden" name="country" value="<?php echo $invoice['user_data']['country']; ?>">
+  <input type="hidden" name="phone" value="<?php echo $invoice['user_data']['phonenumber']; ?>">
+  <input type="hidden" name="email" value="<?php echo $invoice['user_data']['user_email']; ?>">
+
+  <div id="credit_card_information">
+
+    <?php do_action('wpi_payment_fields_twocheckout', $invoice); ?>
+
+    <ul id="wp_invoice_process_wait">
+      <li>
+        <div class="wpi-control-group">
+          <div class="controls">
+            <button type="submit" id="cc_pay_button" class="hide_after_success submit_button"><?php _e('Process Payment of ', WPI); ?><?php echo (!empty($wpi_settings['currency']['symbol'][$invoice['default_currency_code']]) ? $wpi_settings['currency']['symbol'][$invoice['default_currency_code']] : "$"); ?><span id="pay_button_value"><?php echo WPI_Functions::money_format($invoice['net']); ?></span></button>
+          </div>
+          <img style="display: none;" class="loader-img" src="<?php echo WPI_URL; ?>/core/css/images/processing-ajax.gif" alt="" />
+        </div>
+      </li>
+    </ul>
+
+  </div>
+</form>
+
+<?php
+    if ( $invoice['billing']['wpi_twocheckout']['settings']['direct_checkout']['value'] == 'Y' ) {
+        echo '<script src="https://www.2checkout.com/static/checkout/javascript/direct.min.js"></script>';
+    }
+?>

--- a/core/wpi_payment_api.php
+++ b/core/wpi_payment_api.php
@@ -6,8 +6,9 @@
 class WPI_Payment_Api {
 
   const WPI_METHOD_AUTHORIZE_NET   = 'wpi_authorize';
-	const WPI_METHOD_PAYPAL   = 'wpi_paypal';
-	const WPI_METHOD_CHARGIFY = 'wpi_chargify';
+  const WPI_METHOD_PAYPAL   = 'wpi_paypal';
+  const WPI_METHOD_CHARGIFY = 'wpi_chargify';
+  const WPI_METHOD_TWOCHECKOUT = 'wpi_twocheckout';
 
   const WPI_METHOD_STATUS_COMPLETE = 'Complete';
   const WPI_METHOD_STATUS_ERROR    = 'Error';
@@ -51,8 +52,9 @@ class WPI_Payment_Api {
       'x_phone'       => '',
       'x_fax'         => ''
     ),
-		'wpi_paypal' => array(true),
-		'wpi_chargify' => array(true),
+    'wpi_paypal' => array(true),
+    'wpi_chargify' => array(true),
+    'wpi_twocheckout' => array(true),
   );
 
   // Default response object
@@ -161,13 +163,21 @@ class WPI_Payment_Api {
 
           break;
 
-				case self::WPI_METHOD_PAYPAL:
+        case self::WPI_METHOD_PAYPAL:
 
-					$this->response['payment_status'] = self::WPI_METHOD_STATUS_COMPLETE;
-					$this->response['receiver_email'] = !empty( $args['payer_email'] ) ? $args['payer_email'] : '';
-					$this->response['payment_method'] = self::WPI_METHOD_PAYPAL;
+                $this->response['payment_status'] = self::WPI_METHOD_STATUS_COMPLETE;
+                $this->response['receiver_email'] = !empty( $args['payer_email'] ) ? $args['payer_email'] : '';
+                $this->response['payment_method'] = self::WPI_METHOD_PAYPAL;
 
-					break;
+                break;
+
+        case self::WPI_METHOD_TWOCHECKOUT:
+
+                $this->response['payment_status'] = self::WPI_METHOD_STATUS_COMPLETE;
+                $this->response['receiver_email'] = !empty( $args['payer_email'] ) ? $args['payer_email'] : '';
+                $this->response['payment_method'] = self::WPI_METHOD_TWOCHECKOUT;
+
+                break;
 
         case self::WPI_METHOD_CHARGIFY:
 


### PR DESCRIPTION
Adding 2Checkout Payment Method

This adds support for 2Checkout for both recurring and non recurring invoices. Sellers can also choose to use either direct checkout (opens in an overlay) or dynamic checkout (redirects to 2Checkout). I have maintained this code for a while at https://github.com/craigchristenson/2checkout-wp-invoice and it is currently being used in production by 2Checkout sellers.

I just setup a fresh install of wordpress and tested against the development branch to insure that everything is still working as it should.

Let me know if you need anything or would like any changes and thanks for letting me know that you moved to Github. Feel free to throw any merchant (user) questions at me. I am happy to continue maintaining. 
