### PR TITLE
Update class-utility.php

### DIFF
--- a/vendor/usabilitydynamics/lib-ui/lib/class-utility.php
+++ b/vendor/usabilitydynamics/lib-ui/lib/class-utility.php
@@ -71,6 +71,7 @@ namespace UsabilityDynamics\UI {
             $s = str_replace( wp_normalize_path( ABSPATH ), '', get_stylesheet_directory() );
             $s = str_replace( '/', '\/', $s );
             $reg = '|^(.)*(' . $s . ')(.*)$|';
+            $reg = preg_quote( '~'. $reg .'~' );
             $p = preg_replace( $reg, '$3', wp_normalize_path( dirname( __FILE__ ) ) );
             $path = get_stylesheet_directory_uri() . $p;
             break;


### PR DESCRIPTION
Avoid `Warning: preg_replace(): Compilation failed: PCRE does not support \L, \l, \N{name}, \U, or \u at offset 22 in wp-invoice\vendor\usabilitydynamics\lib-ui\lib\class-utility.php on line 74` on Windows hosts
