### PR TITLE
Restore filtering

### DIFF
--- a/vendor/usabilitydynamics/lib-wp-list-table/lib/classes/class-utility.php
+++ b/vendor/usabilitydynamics/lib-wp-list-table/lib/classes/class-utility.php
@@ -33,10 +33,11 @@ namespace UsabilityDynamics\WPLT {
         $path = false;
         switch( $type ) {
           case 'dir':
-            $path = self::_path_dir( $instance );
+            $path = plugin_dir_path( __FILE__ );
+            $path = wp_normalize_path( $path );
             break;
           case 'url':
-            $path = self::_path_url( $instance );
+            $path = plugin_dir_url( __FILE__ );
             break;
         }
         if( $path ) {


### PR DESCRIPTION
Restore invoice filtering by reverting to previous method of determining the path. Broke on 4.0.0 for me on Windows.
