### PR TITLE
fix broken url path

### DIFF
--- a/vendor/usabilitydynamics/lib-ui/lib/class-utility.php
+++ b/vendor/usabilitydynamics/lib-ui/lib/class-utility.php
@@ -36,7 +36,7 @@ namespace UsabilityDynamics\UI {
             $path = self::_path_dir( $instance );
             break;
           case 'url':
-            $path = self::_path_url( $instance );
+            $path = plugin_dir_url( __FILE__ );
             break;
         }
         if( $path ) {


### PR DESCRIPTION
Fix broken url path (on Windows host at least) when overviewing invoices by reverting to the old method of finding the path.

Various js & css files have their paths prepended by the `TEMPLATEPATH` and 404 as a result. 

Example of requested file: `http://example.com/my-wp-content/themes/twentyfifteenD:/localweb/examplesitedir/my-wp-content/plugins/wp-invoice/vendor/usabilitydynamics/lib-ui/static/styles/fields/select.css?ver=4.2.4`

This happens for the following files: 

``` vendor/usabilitydynamics/lib-ui/static/styles/fields/select.css?ver=4.2.4
vendor/usabilitydynamics/lib-ui/static/styles/fields/select-advanced.css?ver=4.2.4 
vendor/usabilitydynamics/lib-ui/static/styles/fields/jqueryui/jquery.ui.datepicker.css?ver=1.8.17 
vendor/usabilitydynamics/lib-ui/static/styles/fields/jqueryui/jquery.ui.core.css?ver=1.8.17 
vendor/usabilitydynamics/lib-ui/static/scripts/fields/select2/select2.js?ver=4.2.4 
vendor/usabilitydynamics/lib-ui/static/scripts/fields/select-advanced.js?ver=4.2.4 
vendor/usabilitydynamics/lib-ui/static/scripts/fields/jqueryui/datepicker-i18n/jquery.ui.datepicker-el.js?ver=1.8.17 
vendor/usabilitydynamics/lib-ui/static/scripts/fields/date.js?ver=4.2.4 
vendor/usabilitydynamics/lib-ui/static/styles/fields/jqueryui/jquery.ui.theme.css?ver=1.8.17 
```
