### PR TITLE
recalculate the length of the elements in the serialized array

### DIFF
--- a/lib/class_invoice.php
+++ b/lib/class_invoice.php
@@ -301,6 +301,7 @@ class WPI_Invoice {
         }
 
         if ( is_serialized($meta_value) ) {
+          $meta_value = preg_replace('!s:(\d+):"(.*?)";!e', "'s:'.strlen('$2').':\"$2\";'", $meta_value); // recalculate the length of the elements in the serialized array
           $tmp_meta_value = unserialize($meta_value);
         } else {
           $tmp_meta_value = $meta_value;


### PR DESCRIPTION
Avoid Notices pollution about 
`unserialize(): Error at offset xx of xxx bytes in wp-invoice\lib\class_invoice.php on line 304`
when visiting the Reports page

Credit to Baba @ http://stackoverflow.com/a/10152996
