### PR TITLE
Fix a couple notice/strict level errors

### DIFF
--- a/lib/class_functions.php
+++ b/lib/class_functions.php
@@ -1467,7 +1467,7 @@ class WPI_Functions {
     }
 
     //** But if recurring settings are defined then invoice type should be recurring */
-    if ( $invoice[ 'recurring' ][ 'active' ] == 'on' && !empty( $invoice['recurring'] ) ) {
+    if ( !empty( $invoice['recurring'] ) && $invoice[ 'recurring' ][ 'active' ] == 'on' ) {
       $ni->create_schedule( $invoice['recurring'] );
       $invoice_type = 'recurring';
     }

--- a/lib/class_ui.php
+++ b/lib/class_ui.php
@@ -1006,7 +1006,7 @@ class WPI_UI {
   /**
    * Can overwite page title (heading)
    */
-  function the_title( $title = '', $post_id = '' ) {
+  static function the_title( $title = '', $post_id = '' ) {
     global $wpi_settings, $invoice_id, $wpdb;
     if ( $post_id == $wpi_settings[ 'web_invoice_page' ] ) {
       if ( $wpi_settings[ 'hide_page_title' ] == 'true' ) {


### PR DESCRIPTION
1. \- Fixes a notice level error when saving the invoice that mentions the recurring key is not set.
2. \- Fixes a strict level error that mentions that the_title() is not s static method although it has been added to add_action() with static usage.
