### PR TITLE
PHP 7.1 Deprecated constructor fix

### DIFF
--- a/lib/class_settings.php
+++ b/lib/class_settings.php
@@ -19,11 +19,11 @@ class WPI_Settings {
   var $data;
 
   /**
-   * Cunstruct
+   * Construct
    *
    * @param object $Core
    */
-  function WPI_Settings( &$Core ) {
+  function __construct( &$Core ) {
     $this->Core = $Core;
     $this->LoadOptions();
   }


### PR DESCRIPTION
PHP7.1 is getting to be more aggressive about PHP4 constructors. This very small change removes the a use of the old style constructor in WPI_Settings, thus improving support for PHP 7.1