### PR TITLE
Call invoice count query only in template where used

### DIFF
--- a/lib/class_core.php
+++ b/lib/class_core.php
@@ -173,7 +173,6 @@ class WPI_Core {
 
     //** Set additional dynamic settings */
     $wpi_settings['frontend_path'] = $this->frontend_path;
-    $wpi_settings['total_invoice_count'] = $wpdb->get_var("SELECT COUNT(*) FROM " . $wpdb->posts . " WHERE post_type = 'wpi_object' AND post_title != ''");
     $wpi_settings['links']['overview_page'] = 'admin.php?page=wpi_main';
     $wpi_settings['links']['settings_page'] = 'admin.php?page=wpi_page_settings';
     $wpi_settings['links']['manage_invoice'] = 'admin.php?page=wpi_page_manage_invoice';

--- a/lib/ui/user_selection_form.php
+++ b/lib/ui/user_selection_form.php
@@ -1,6 +1,7 @@
 <?php
 
   global $wpi_settings, $wpdb;
+  $invoice_count = $wpdb->get_var("SELECT COUNT(*) FROM {$wpdb->posts} WHERE post_type = 'wpi_object' AND post_title != ''");
 
 ?>
 
@@ -16,12 +17,12 @@
             <td>
               <?php WPI_UI::draw_user_auto_complete_field(); ?>
               <input type="submit" class="button" id="wp_invoice_create_new_invoice" value="<?php esc_attr(_e('Create New', ud_get_wp_invoice()->domain)); ?>">
-              <?php if($wpi_settings['total_invoice_count']) : ?>
+              <?php if($invoice_count) : ?>
               <span id="wp_invoice_copy_invoice" class="wp_invoice_click_me"><?php _e( 'copy from another', ud_get_wp_invoice()->domain ) ?></span>
               <?php endif; ?>
             </td>
           </tr>
-          <?php if($wpi_settings['total_invoice_count']) : ?>
+          <?php if($invoice_count) : ?>
           <tr class="wp_invoice_copy_invoice invoice_main">
             <th><label for="wpi_template_lookup"><?php _e('Existing Invoice:', ud_get_wp_invoice()->domain); ?></label></th>
             <td>


### PR DESCRIPTION
Checking for existing invoices is done via:
`$wpdb->get_var("SELECT COUNT(*) FROM {$wpdb->posts} WHERE post_type = 'wpi_object' AND post_title != ''");`
The result of this query is only used on the user_selection_form template. Currently this query runs on every page load.

This pull request moves this query to the template where it is being used and prevents this query from running on every page load without purpose. 